### PR TITLE
GH CI for releases on crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Publish after Release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  run_after_release:
+    name: crates.io publish
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+      RUSTDOCFLAGS: "-D warnings"
+    steps:
+      - name: Update sources
+        run: sudo apt update
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable minus 2 releases
+      - name: cargo publish
+        run: |
+          cargo login ${{ secrets.CRATES_IO_API_TOKEN }}
+          cargo publish --no-verify


### PR DESCRIPTION
Direct copy from 
https://github.com/Grinkers/clojure-reader/blob/5df5f351c83ee8437baac2eb2125afa5217b1163/.github/workflows/release.yml