### PR TITLE
 websocket_broadcaster: ignore timeouts when reading from clients. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tii"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 authors = ["Alexander Schuetz <aschuetz@protonmail.com>", "Kevin Nakamura <grinkers@grinkers.net>"]
 license = "MIT"

--- a/examples/websocket_broadcast.rs
+++ b/examples/websocket_broadcast.rs
@@ -7,6 +7,8 @@ use tii::ServerBuilder;
 use tii::WebsocketMessage;
 
 fn main() -> Result<(), Box<dyn Error>> {
+  trivial_log::init_std(log::LevelFilter::Debug).unwrap();
+
   let websocket_linker = WSBAppBuilder::default()
     .with_message_handler(message_handler)
     .with_connect_handler(connect_handler)
@@ -43,6 +45,7 @@ fn main() -> Result<(), Box<dyn Error>> {
   // This explicit drop and join is optional. In this case, it gets sanity checked with Valgrind
   drop(app);
   websocket_thread.join().unwrap();
+  trivial_log::free();
   Ok(())
 }
 


### PR DESCRIPTION
It would probably be smart to actually use the Pongs, instead of relying solely on the sockets disconnecting, but this fixes an issue where clients don't have much to say.

Doing a 0.0.3 version bump so I can test on HEAD with crates.io's immutable release.