### PR TITLE
remove platform-dependent code from connectors in extras.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,17 +25,12 @@ base64 = "0.22.1"
 defer-heavy = "0.1.0"
 #GZIP/ZLIB in pure rust
 libflate = "2.1.0"
+listener_poll = { version = "0.1.0", optional = true }
 
 
 ## SSL
 rustls = { version = "0.23.26", optional = true }
 rust-tls-duplex-stream = { version = "0.1.1", optional = true }
-
-[target.'cfg(unix)'.dependencies]
-libc = { version = "0.2", optional = true }
-
-[target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.60.1", optional = true, features = ["Win32_Networking_WinSock"] }
 
 [dev-dependencies]
 rustls = "0.23.26"
@@ -49,7 +44,7 @@ serde_json = "1.0.140"
 default = []
 random_id = ["getrandom"]
 tls = ["rust-tls-duplex-stream", "rustls"]
-extras = ["libc", "windows-sys"]
+extras = ["listener_poll"]
 
 [lints.rust]
 future-incompatible = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,11 +35,13 @@ rust-tls-duplex-stream = { version = "0.2.0", optional = true }
 [dev-dependencies]
 rustls =  { version = "0.23.28", default-features = false, features = ["std"] }
 rustls-pemfile = "2.2.0"
-rustls-graviola = "0.2.1"
 trivial_log = "^0.1"
 log = "0.4.27"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+
+[target.'cfg(any(target_arch="x86_64", target_arch="aarch64"))'.dev-dependencies]
+rustls-graviola = "0.2.1"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,13 @@ listener_poll = { version = "0.1.1", optional = true }
 
 
 ## SSL
-rustls = { version = "0.23.26", optional = true }
-rust-tls-duplex-stream = { version = "0.1.1", optional = true }
+rustls = { version = "0.23", optional = true, default-features = false, features = ["std"] }
+rust-tls-duplex-stream = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
-rustls = "0.23.26"
+rustls =  { version = "0.23.28", default-features = false, features = ["std"] }
 rustls-pemfile = "2.2.0"
+rustls-graviola = "0.2.1"
 trivial_log = "^0.1"
 log = "0.4.27"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ base64 = "0.22.1"
 defer-heavy = "0.1.0"
 #GZIP/ZLIB in pure rust
 libflate = "2.1.0"
-listener_poll = { version = "0.1.0", optional = true }
+listener_poll = { version = "0.1.1", optional = true }
 
 
 ## SSL

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -40,6 +40,11 @@ fn create_rust_tls_server_config() -> Arc<ServerConfig> {
 fn main() -> TiiResult<()> {
   trivial_log::init_std(log::LevelFilter::Debug).unwrap();
 
+  //Use a different tls provider if you so desire at your convenience.
+  rustls_graviola::default_provider()
+      .install_default()
+      .unwrap();
+
   let app =
     ServerBuilder::builder_arc(|builder| builder.router(|r| r.route_any("/tls", tls_route)))?;
   let config = create_rust_tls_server_config();

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -40,10 +40,16 @@ fn create_rust_tls_server_config() -> Arc<ServerConfig> {
 fn main() -> TiiResult<()> {
   trivial_log::init_std(log::LevelFilter::Debug).unwrap();
 
-  //Use a different tls provider if you so desire at your convenience.
-  rustls_graviola::default_provider()
-      .install_default()
-      .unwrap();
+  // Use a different tls provider if you so desire at your convenience.
+  // Different providers require you to install native dependencies/c-compilers etc. 
+  // This one only needs pure rust and therefore works on any os/env out of the box.
+  // It does, however, only work on x86_64/aarch64 so this example will not work on other cpu targets.
+  #[cfg(any(target_arch="x86_64", target_arch="aarch64"))]
+  {
+    rustls_graviola::default_provider()
+        .install_default()
+        .unwrap();
+  }
 
   let app =
     ServerBuilder::builder_arc(|builder| builder.router(|r| r.route_any("/tls", tls_route)))?;

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -41,14 +41,12 @@ fn main() -> TiiResult<()> {
   trivial_log::init_std(log::LevelFilter::Debug).unwrap();
 
   // Use a different tls provider if you so desire at your convenience.
-  // Different providers require you to install native dependencies/c-compilers etc. 
+  // Different providers require you to install native dependencies/c-compilers etc.
   // This one only needs pure rust and therefore works on any os/env out of the box.
   // It does, however, only work on x86_64/aarch64 so this example will not work on other cpu targets.
-  #[cfg(any(target_arch="x86_64", target_arch="aarch64"))]
+  #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
   {
-    rustls_graviola::default_provider()
-        .install_default()
-        .unwrap();
+    rustls_graviola::default_provider().install_default().unwrap();
   }
 
   let app =

--- a/src/extras/connector.rs
+++ b/src/extras/connector.rs
@@ -12,12 +12,15 @@ use std::time::Duration;
 /// the listener thread and the time it takes for the listener thread to process a few of lines of code.
 ///
 /// If this value is too small:
-/// On Windows worst case is that we fail to wake up the listener thread.
+/// Worst case is that we fail to wake up the listener thread.
 /// Otherwise, is that we log an error and later succeed.
 ///
 /// If this value is too big:
 /// We may block for this amount of time without the user of tii expecting it.
 pub(crate) const CONNECTOR_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// See above
+pub(crate) const CONNECTOR_SHUTDOWN_FLAG_POLLING_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Trait that defines all fn's that each connector implemented by tii::extras has.
 pub trait Connector {

--- a/src/extras/mod.rs
+++ b/src/extras/mod.rs
@@ -2,6 +2,7 @@ pub mod builtin_endpoints;
 
 mod connector;
 
+pub(crate) use connector::CONNECTOR_SHUTDOWN_FLAG_POLLING_INTERVAL;
 pub(crate) use connector::CONNECTOR_SHUTDOWN_TIMEOUT;
 pub use {connector::Connector, connector::ConnectorMeta};
 

--- a/src/extras/tcp_connector.rs
+++ b/src/extras/tcp_connector.rs
@@ -1,10 +1,13 @@
 use crate::extras::connector::{ActiveConnection, ConnWait};
-use crate::extras::{Connector, ConnectorMeta, CONNECTOR_SHUTDOWN_TIMEOUT};
+use crate::extras::{
+  Connector, ConnectorMeta, CONNECTOR_SHUTDOWN_FLAG_POLLING_INTERVAL, CONNECTOR_SHUTDOWN_TIMEOUT,
+};
 use crate::functional_traits::{DefaultThreadAdapter, ThreadAdapter, ThreadAdapterJoinHandle};
 use crate::tii_error::TiiResult;
 use crate::tii_server::Server;
 use crate::{error_log, info_log, trace_log};
 use defer_heavy::defer;
+use listener_poll::PollEx;
 use std::io;
 use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -29,45 +32,18 @@ struct TcpConnectorInner {
 }
 
 impl TcpConnectorInner {
-  #[cfg(target_os = "windows")]
-  #[expect(unsafe_code)]
   fn next(&self) -> io::Result<TcpStream> {
-    use std::os::windows::io::AsRawSocket;
-    use windows_sys::Win32::Networking::WinSock::{
-      WSAGetLastError, WSAPoll, POLLRDNORM, SOCKET_ERROR, WSAPOLLFD,
-    };
-
-    let windows_sock_handle = self.listener.as_raw_socket() as usize;
-
     loop {
-      let mut pollfd =
-        Box::pin(WSAPOLLFD { fd: windows_sock_handle, events: POLLRDNORM, revents: 0 });
-
-      let result = unsafe {
-        //https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsapoll
-        WSAPoll(pollfd.as_mut().get_mut(), 1, 1000)
-      };
-      drop(pollfd);
       if self.tii_server.is_shutdown() || self.shutdown_flag.load(Ordering::SeqCst) {
         return Err(io::ErrorKind::ConnectionAborted.into());
       }
 
-      if result == SOCKET_ERROR {
-        unsafe {
-          return Err(io::Error::from_raw_os_error(WSAGetLastError()));
-        }
-      }
-
-      if result == 0 {
+      if !self.listener.poll(Some(CONNECTOR_SHUTDOWN_FLAG_POLLING_INTERVAL))? {
         continue;
       }
 
       return self.listener.accept().map(|(stream, _)| stream);
     }
-  }
-  #[cfg(not(target_os = "windows"))]
-  fn next(&self) -> io::Result<TcpStream> {
-    self.listener.accept().map(|(stream, _)| stream)
   }
 
   fn run(&self) {
@@ -196,42 +172,6 @@ impl TcpConnectorInner {
 }
 
 impl TcpConnectorInner {
-  #[expect(unsafe_code)]
-  #[cfg(unix)]
-  fn shutdown(&self) {
-    use std::os::fd::AsRawFd;
-
-    if self.shutdown_flag.swap(true, Ordering::SeqCst) {
-      return;
-    }
-
-    if self.waiter.is_done(1) {
-      //No need to libc::shutdown() if somehow by magic the main_thread is already dead.
-      return;
-    }
-
-    unsafe {
-      if libc::shutdown(self.listener.as_raw_fd(), libc::SHUT_RDWR) != -1 {
-        if !self.waiter.wait(1, Some(CONNECTOR_SHUTDOWN_TIMEOUT)) {
-          error_log!(
-            "tii: tcp_connector[{}]: shutdown failed to wake up the listener thread",
-            &self.addr_string
-          );
-          return;
-        }
-
-        return;
-      }
-
-      //This is very unlikely; I have NEVER seen this happen.
-      let errno = io::Error::last_os_error();
-      if !self.waiter.wait(1, Some(CONNECTOR_SHUTDOWN_TIMEOUT)) {
-        error_log!("tii: tcp_connector[{}]: shutdown failed: errno={}", &self.addr_string, errno);
-      }
-    }
-  }
-
-  #[cfg(target_os = "windows")]
   pub fn shutdown(&self) {
     if self.shutdown_flag.swap(true, Ordering::SeqCst) {
       return;
@@ -246,11 +186,6 @@ impl TcpConnectorInner {
   }
 }
 impl Connector for TcpConnector {
-  #[cfg(unix)]
-  fn shutdown(&self) {
-    self.inner.shutdown();
-  }
-  #[cfg(not(unix))]
   fn shutdown(&self) {
     self.inner.shutdown();
   }
@@ -343,6 +278,8 @@ impl TcpConnector {
       waiter: ConnWait::default(),
     });
 
+    inner.listener.set_nonblocking(true)?;
+
     let main_thread = {
       let inner = inner.clone();
       thread_adapter.spawn(Box::new(move || {
@@ -371,11 +308,4 @@ impl TcpConnector {
   pub fn start_unpooled(addr: impl ToSocketAddrs, tii_server: Arc<Server>) -> TiiResult<Self> {
     Self::start(addr, tii_server, DefaultThreadAdapter)
   }
-}
-
-#[cfg(target_os = "windows")]
-#[test]
-pub fn test_windows_ptr_sanity() {
-  use std::os::windows::io::RawSocket;
-  assert_eq!(size_of::<RawSocket>(), size_of::<usize>());
 }

--- a/src/extras/tcp_connector.rs
+++ b/src/extras/tcp_connector.rs
@@ -142,7 +142,7 @@ impl TcpConnectorInner {
 
     self.waiter.signal(1);
 
-    trace_log!("tcp_connector[{}]: waiting for shutdown to finish", &self.addr_string);
+    trace_log!("tii: tcp_connector[{}]: waiting for shutdown to finish", &self.addr_string);
     //Wait for all threads to finish
     for mut con in active_connection {
       let this_connection = con.id;


### PR DESCRIPTION
That logic now outsourced to the listener_poll crate.